### PR TITLE
Issues: #10    Fix the bug that can't get storage_pool by a volume from the GetResourceView.

### DIFF
--- a/client/resource.go
+++ b/client/resource.go
@@ -197,7 +197,7 @@ type ResourceState struct {
 // Volume is a struct which holds the information about a linstor-volume
 type Volume struct {
 	VolumeNumber     int32        `json:"volume_number,omitempty"`
-	StoragePool      string       `json:"storage_pool,omitempty"`
+	StoragePoolName  string       `json:"storage_pool_name,omitempty"`
 	ProviderKind     ProviderKind `json:"provider_kind,omitempty"`
 	DevicePath       string       `json:"device_path,omitempty"`
 	AllocatedSizeKib int64        `json:"allocated_size_kib,omitempty"`


### PR DESCRIPTION
Fix the bug that can't get storage_pool by a volume from the GetResourceView.

When I use Resources.GetResourceView() to get the resource list with
volume， but can't get the volume.StoragePool, the value is always "".
And then I find the api response is storage_pool_name from /v1/view/resources.
but in our code, it use storage_pool to encode storage_pool_name, so it's
not valid.

Then I fix the bug by change the storage_pool to storage_pool_name.