### PR TITLE
Fix first Controller address being overwritten

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -495,8 +495,8 @@ func (c *Client) findRespondingController() error {
 	for i := range errs {
 		if errs[i] == nil {
 			tmp := c.controllers[i]
-			c.controllers[0] = c.controllers[i]
-			c.controllers[i] = tmp
+			c.controllers[i] = c.controllers[0]
+			c.controllers[0] = tmp
 			return nil
 		}
 	}


### PR DESCRIPTION
When a new controller gets selected, the first controller in the list gets completely overwritten because of a faulty swap mechanism.